### PR TITLE
fix timeout

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,7 +33,7 @@ var client = &http.Client{
 		TLSNextProto:        map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 		MaxIdleConnsPerHost: 999,
 	},
-	Timeout: time.Second * 5,
+	Timeout: time.Second * 20,
 }
 
 var clienth2 = &http.Client{


### PR DESCRIPTION
fuqiuluo/unidbg-fetch-qsign#112
修复由于低频服务器生成签名值过慢，在对接qsign时有概率timeout。